### PR TITLE
Fix training

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ or new features are supported. This is still expected to be compatible to an ear
 
 Builds against XGBoost 3.0.0.
 
-Deactivated test:
-
-- booster::dump_model, reason: Output seems to be empty.
-
 ## Use prebuilt xgboost library or build it
 
 Xgboost is kind of complicated to compile, especially when there is GPU support involved.

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dave Challis <dave@suicas.net>"]
 publish = false
 
 [dependencies]
-xgboost = { path = "../../" }
+xgb = { path = "../../" }
 sprs = "0.11"
 log = "0.4"
 env_logger = "0.5"

--- a/examples/custom_objective/Cargo.toml
+++ b/examples/custom_objective/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Dave Challis <dave@suicas.net>"]
 publish = false
 
 [dependencies]
-xgboost = { path = "../../" }
+xgb = { path = "../../" }
 ndarray = "0.11"

--- a/examples/generalised_linear_model/Cargo.toml
+++ b/examples/generalised_linear_model/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dave Challis <dave@suicas.net>"]
 publish = false
 
 [dependencies]
-xgboost = { path = "../../" }
+xgb = { path = "../../" }
 ndarray = "0.11"
 log = "0.4"
 env_logger = "0.5"

--- a/examples/multiclass_classification/Cargo.toml
+++ b/examples/multiclass_classification/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dave Challis <dave@suicas.net>"]
 publish = false
 
 [dependencies]
-xgboost = { path = "../../" }
+xgb = { path = "../../" }
 log = "0.4"
 env_logger = "0.5"
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -197,8 +197,15 @@ impl Booster {
             dmats
         };
 
-        let bst = Booster::new_with_cached_dmats(&params.booster_params, &cached_dmats)?;
+        let mut bst = Booster::new_with_cached_dmats(&params.booster_params, &cached_dmats)?;
         for i in 0..params.boost_rounds as i32 {
+            debug!("Updating in round: {}", i);
+            if let Some(objective_fn) = params.custom_objective_fn {
+                bst.update_custom(params.dtrain, objective_fn)?;
+            } else {
+                bst.update(params.dtrain, i)?;
+            }
+
             if let Some(eval_sets) = params.evaluation_sets {
                 let mut dmat_eval_results = bst.eval_set(eval_sets, i)?;
 
@@ -1235,7 +1242,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn dump_model() {
         let dmat_train =
             DMatrix::load(r#"{"uri": "xgboost-sys/xgboost/demo/data/agaricus.txt.train?format=libsvm"}"#).unwrap();


### PR DESCRIPTION
98604a006d8959f9c605deb122c0beb507dfd5c8 lost calls to update, so train function didn't actually train the booster.

This was also the reason why dump_model test was failing, because the model wasn't trained