### PR TITLE
change release source and add upload release script

### DIFF
--- a/.github/workflows/prebuilt-libs.yml
+++ b/.github/workflows/prebuilt-libs.yml
@@ -47,4 +47,7 @@ jobs:
       - name: Upload and verify release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./scripts/upload-release-libs.sh "${{ inputs.tag }}"
+          # Via the environment, not an inline expansion: the value is attacker-controlled on a
+          # workflow_dispatch. Empty on a release event, which lets the script fall back to LIB_TAG.
+          TAG: ${{ inputs.tag }}
+        run: ./scripts/upload-release-libs.sh "$TAG"

--- a/.github/workflows/prebuilt-libs.yml
+++ b/.github/workflows/prebuilt-libs.yml
@@ -1,0 +1,50 @@
+name: Prebuilt libs
+
+on:
+  push:
+    paths:
+      - "xgboost-sys/build.rs"
+      - "xgboost-sys/lib/**"
+      - "scripts/upload-release-libs.sh"
+      - ".github/workflows/prebuilt-libs.yml"
+  pull_request:
+    paths:
+      - "xgboost-sys/build.rs"
+      - "xgboost-sys/lib/**"
+      - "scripts/upload-release-libs.sh"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to upload to. Defaults to LIB_TAG in build.rs."
+        required: false
+        type: string
+
+jobs:
+  # Catches drift between the checksums pinned in build.rs and the files committed under
+  # xgboost-sys/lib, which would otherwise only surface as a failed build on a user's machine.
+  verify:
+    name: verify pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check committed libraries against build.rs
+        run: ./scripts/upload-release-libs.sh --dry-run
+
+  # Assets are published against LIB_TAG, not against the release that triggered this run: the
+  # checksums in build.rs pin that tag's bytes, so that is the release the build script downloads
+  # from. Re-running is harmless, uploads use --clobber.
+  upload:
+    name: upload assets
+    needs: verify
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload and verify release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/upload-release-libs.sh "${{ inputs.tag }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xgb"
-version = "3.0.5"
+version = "3.0.6"
 authors = ["Dave Challis <dave@suicas.net>", "Marco Mengelkoch"]
 license = "MIT"
 repository = "https://github.com/marcomq/rust-xgboost"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-xgboost-sys = { package = "xgboost_lib-sys", path = "xgboost-sys", version = "3.0.4" }
+xgboost-sys = { package = "xgboost_lib-sys", path = "xgboost-sys", version = "3.0.5" }
 libc = "0.2"
 derive_builder = "0.20"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ This is using a prebuilt shared library in xboost-sys/lib by default. You can al
 The library is looked up in the following order, so a build only reaches the network when it has to:
 
 1. `$XGBOOST_LIB_DIR` - link against an existing directory, nothing is copied or downloaded
-2. `$XGBOOST_LIB_CACHE`, defaulting to `$CARGO_HOME/xgboost-prebuilt/<tag>` - a download cache that
+2. `target/<profile>/deps/` - the copy an earlier build of this crate already put in place, reused
+   only if it still matches the pinned checksum
+3. `$XGBOOST_LIB_CACHE`, defaulting to `$CARGO_HOME/xgboost-prebuilt/<tag>` - a download cache that
    survives `cargo clean` and is shared between checkouts
-3. `xgboost-sys/lib/<platform>/` - the copies in this repository, present in a git checkout but not
+4. `xgboost-sys/lib/<platform>/` - the copies in this repository, present in a git checkout but not
    in the published crate
-4. Download, trying `$XGBOOST_LIB_URL` first if set, then the bundled mirrors in turn
+5. Download, trying `$XGBOOST_LIB_URL` first if set, then the bundled mirrors in turn
 
 Every file is pinned by SHA-256. A download that does not match, including an error page served
 during an outage, is rejected and the next source is tried. Files already on disk are re-checked on
@@ -126,9 +128,12 @@ subsequent build.
 
 To download from your own mirror, expose the files as `<base>/<platform>/<file>` and set:
 
-```
+```sh
 XGBOOST_LIB_URL=https://your-mirror.example/xgboost-libs
 ```
+
+A base URL containing `/releases/download/` is treated as a GitHub release instead, whose asset
+namespace is flat: the files are looked up as `<base>/<platform>-<file>`.
 
 For a fully offline build, either point `$XGBOOST_LIB_DIR` at a prepared directory, or place the
 files in `$XGBOOST_LIB_CACHE/<platform>/`.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,33 @@ Xgboost is kind of complicated to compile, especially when there is GPU support 
 It is sometimes easier to use a pre-build library. Therefore, the feature flag `use_prebuilt_xgb` is enabled by default.
 This is using a prebuilt shared library in xboost-sys/lib by default. You can also use a custom folder by defining `$XGBOOST_LIB_DIR`.
 
+The library is looked up in the following order, so a build only reaches the network when it has to:
+
+1. `$XGBOOST_LIB_DIR` - link against an existing directory, nothing is copied or downloaded
+2. `$XGBOOST_LIB_CACHE`, defaulting to `$CARGO_HOME/xgboost-prebuilt/<tag>` - a download cache that
+   survives `cargo clean` and is shared between checkouts
+3. `xgboost-sys/lib/<platform>/` - the copies in this repository, present in a git checkout but not
+   in the published crate
+4. Download, trying `$XGBOOST_LIB_URL` first if set, then the bundled mirrors in turn
+
+Every file is pinned by SHA-256. A download that does not match, including an error page served
+during an outage, is rejected and the next source is tried. Files already on disk are re-checked on
+each build, so a bad copy from an earlier build repairs itself rather than breaking every
+subsequent build.
+
+To download from your own mirror, expose the files as `<base>/<platform>/<file>` and set:
+
+```
+XGBOOST_LIB_URL=https://your-mirror.example/xgboost-libs
+```
+
+For a fully offline build, either point `$XGBOOST_LIB_DIR` at a prepared directory, or place the
+files in `$XGBOOST_LIB_CACHE/<platform>/`.
+
+On macOS the prebuilt dylib is stamped with an absolute Homebrew install name. The build rewrites
+it to the copy it just verified and re-signs it ad-hoc, so the pinned library is the one loaded at
+runtime rather than whatever Homebrew happens to have installed.
+
 If you prefer to use xgboost from homebrew, which may have GPU support, your can for example define
 ```
 XGBOOST_LIB_DIR=${HOMEBREW_PREFIX}/opt/xgboost/lib

--- a/scripts/upload-release-libs.sh
+++ b/scripts/upload-release-libs.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Publish the prebuilt XGBoost libraries in xgboost-sys/lib as GitHub release assets.
+#
+# The asset names and checksums are read from xgboost-sys/build.rs, which is the single source of
+# truth: the build script resolves release assets as <base>/<platform>-<file> (a release's asset
+# namespace is flat), so an asset uploaded under any other name is invisible to it. Every file is
+# checked against its pinned SHA-256 before upload and re-downloaded and checked again afterwards,
+# so a release can never end up serving bytes the build script would reject.
+#
+# Usage:
+#   scripts/upload-release-libs.sh [--dry-run] [tag]
+#
+# The tag defaults to LIB_TAG in build.rs. Requires the `gh` CLI, authenticated with a token that
+# can write releases.
+
+set -euo pipefail
+
+DRY_RUN=false
+TAG=""
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h | --help)
+            sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            echo "unknown option: $arg" >&2
+            exit 2
+            ;;
+        *) TAG="$arg" ;;
+    esac
+done
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUILD_RS="$REPO_ROOT/xgboost-sys/build.rs"
+LIB_DIR="$REPO_ROOT/xgboost-sys/lib"
+
+[ -f "$BUILD_RS" ] || {
+    echo "not found: $BUILD_RS" >&2
+    exit 1
+}
+[ -d "$LIB_DIR" ] || {
+    echo "not found: $LIB_DIR (the prebuilt libraries are absent from the published crate)" >&2
+    exit 1
+}
+
+if [ -z "$TAG" ]; then
+    TAG=$(sed -n 's/^const LIB_TAG: &str = "\(.*\)";$/\1/p' "$BUILD_RS")
+    [ -n "$TAG" ] || {
+        echo "could not read LIB_TAG from $BUILD_RS" >&2
+        exit 1
+    }
+fi
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+# Emits "<platform> <file> <sha256>" per pinned artifact, in build.rs order.
+read_manifest() {
+    awk '
+        /^[[:space:]]*"[a-z0-9_]+" => &\[/ {
+            match($0, /"[a-z0-9_]+"/)
+            platform = substr($0, RSTART + 1, RLENGTH - 2)
+            next
+        }
+        /^[[:space:]]*file: "/   { match($0, /"[^"]+"/); file = substr($0, RSTART + 1, RLENGTH - 2); next }
+        /^[[:space:]]*sha256: "/ { match($0, /"[^"]+"/); print platform, file, substr($0, RSTART + 1, RLENGTH - 2) }
+    ' "$BUILD_RS"
+}
+
+MANIFEST=$(read_manifest)
+[ -n "$MANIFEST" ] || {
+    echo "no artifacts parsed from $BUILD_RS" >&2
+    exit 1
+}
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Release tag: $TAG"
+echo "Staging assets from $LIB_DIR"
+
+count=0
+while read -r platform file sha; do
+    src="$LIB_DIR/$platform/$file"
+    if [ ! -f "$src" ]; then
+        echo "  MISSING  $platform/$file" >&2
+        exit 1
+    fi
+    actual=$(sha256_of "$src")
+    if [ "$actual" != "$sha" ]; then
+        echo "  MISMATCH $platform/$file" >&2
+        echo "           on disk: $actual" >&2
+        echo "           pinned:  $sha" >&2
+        echo "Refusing to upload: build.rs would reject this file." >&2
+        exit 1
+    fi
+    # Must match `mirror_url` in build.rs for release URLs.
+    cp "$src" "$STAGE/$platform-$file"
+    echo "  ok       $platform-$file"
+    count=$((count + 1))
+done <<<"$MANIFEST"
+
+echo "$count assets staged."
+
+if [ "$DRY_RUN" = true ]; then
+    echo "Dry run, nothing uploaded. Would upload to release $TAG:"
+    ls -1 "$STAGE"
+    exit 0
+fi
+
+command -v gh >/dev/null 2>&1 || {
+    echo "gh CLI not found" >&2
+    exit 1
+}
+
+# Report what gh actually said. A missing release, an expired login and a remote pointing at a
+# fork all fail here, and they need different fixes.
+if ! gh_err=$(gh release view "$TAG" 2>&1 >/dev/null); then
+    echo "cannot read release $TAG:" >&2
+    echo "  $gh_err" >&2
+    echo >&2
+    echo "repo gh resolved: $(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1 || echo '<unknown>')" >&2
+    echo "auth status:" >&2
+    gh auth status 2>&1 | sed 's/^/  /' >&2
+    echo >&2
+    echo "If the release genuinely does not exist: gh release create $TAG" >&2
+    exit 1
+fi
+
+echo "Uploading to release $TAG"
+# shellcheck disable=SC2046  # staged names are controlled above and contain no whitespace
+gh release upload "$TAG" $(ls -d "$STAGE"/*) --clobber
+
+echo "Verifying published assets"
+BASE="https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/download/$TAG"
+failed=0
+while read -r platform file sha; do
+    url="$BASE/$platform-$file"
+    tmp="$STAGE/.verify"
+    if ! curl -fsSL "$url" -o "$tmp"; then
+        echo "  FAILED   $platform-$file (download)" >&2
+        failed=1
+        continue
+    fi
+    actual=$(sha256_of "$tmp")
+    if [ "$actual" != "$sha" ]; then
+        echo "  MISMATCH $platform-$file (served $actual)" >&2
+        failed=1
+    else
+        echo "  verified $platform-$file"
+    fi
+done <<<"$MANIFEST"
+
+[ "$failed" -eq 0 ] || {
+    echo "Some assets are not serving the pinned bytes." >&2
+    exit 1
+}
+echo "All $count assets published and verified against build.rs."

--- a/scripts/upload-release-libs.sh
+++ b/scripts/upload-release-libs.sh
@@ -142,16 +142,30 @@ gh release upload "$TAG" $(ls -d "$STAGE"/*) --clobber
 echo "Verifying published assets"
 BASE="https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/download/$TAG"
 failed=0
+# A just-uploaded asset can 404 or briefly serve the previous bytes while the CDN catches up, so
+# retry before declaring a failure. Only a mismatch that survives every attempt is real.
+ATTEMPTS=3
 while read -r platform file sha; do
     url="$BASE/$platform-$file"
     tmp="$STAGE/.verify"
-    if ! curl -fsSL "$url" -o "$tmp"; then
-        echo "  FAILED   $platform-$file (download)" >&2
+    downloaded=false
+    actual=""
+    for attempt in $(seq 1 "$ATTEMPTS"); do
+        if [ "$attempt" -gt 1 ]; then
+            sleep $((attempt - 1))
+        fi
+        if curl -fsSL "$url" -o "$tmp"; then
+            downloaded=true
+            actual=$(sha256_of "$tmp")
+            if [ "$actual" = "$sha" ]; then
+                break
+            fi
+        fi
+    done
+    if [ "$downloaded" = false ]; then
+        echo "  FAILED   $platform-$file (download, $ATTEMPTS attempts)" >&2
         failed=1
-        continue
-    fi
-    actual=$(sha256_of "$tmp")
-    if [ "$actual" != "$sha" ]; then
+    elif [ "$actual" != "$sha" ]; then
         echo "  MISMATCH $platform-$file (served $actual)" >&2
         failed=1
     else

--- a/xgboost-sys/Cargo.toml
+++ b/xgboost-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xgboost_lib-sys"
-version = "3.0.4"
+version = "3.0.5"
 authors = ["Dave Challis <dave@suicas.net>", "Marco Mengelkoch"]
 links = "xgboost"
 build = "build.rs"
@@ -19,11 +19,12 @@ libc = "0.2"
 [build-dependencies]
 bindgen = { version = "0.71" }
 dunce =  { version = "1.0.5" }
-reqwest = { version = "0.12.15", features = ["blocking"], optional = true }
-cmake = { version = "0.1", optional = true } 
+ureq = { version = "3", optional = true }
+sha2 = { version = "0.10", optional = true }
+cmake = { version = "0.1", optional = true }
 
 [features]
 default = ["use_prebuilt_xgb"]
-use_prebuilt_xgb = ["reqwest"]
+use_prebuilt_xgb = ["ureq", "sha2"]
 local_build = ["cmake"]
 cuda = []

--- a/xgboost-sys/build.rs
+++ b/xgboost-sys/build.rs
@@ -2,7 +2,21 @@ use bindgen;
 use std::env;
 use std::path::{Path, PathBuf};
 
-const GITHUB_URL: &str = "https://github.com/marcomq/rust-xgboost/raw/refs/tags/v3.0.1/xgboost-sys/lib/";
+/// Tag the prebuilt libraries are pinned to. Must match the checksums in `prebuilt_artifacts`.
+///
+/// This tracks the libraries, not the crate version: it only moves when the binaries themselves
+/// change, so a crate release that leaves them untouched keeps pointing at the same verified bytes.
+#[cfg(feature = "use_prebuilt_xgb")]
+const LIB_TAG: &str = "v3.0.5";
+
+/// Base URLs tried in order when an artifact has to be downloaded. Each entry is expanded by
+/// `mirror_url`, so a mirror may lay its files out either as `<base>/<platform>/<file>` or, for
+/// GitHub release assets, as `<base>/<platform>-<file>`.
+#[cfg(feature = "use_prebuilt_xgb")]
+const MIRRORS: &[&str] = &[
+    "https://github.com/marcomq/rust-xgboost/raw/refs/tags/v3.0.5/xgboost-sys/lib",
+    "https://github.com/marcomq/rust-xgboost/releases/download/v3.0.5",
+];
 
 fn main() {
     let target = env::var("TARGET").unwrap();
@@ -33,46 +47,34 @@ fn main() {
 
     #[cfg(feature = "use_prebuilt_xgb")]
     {
+        for var in ["XGBOOST_LIB_DIR", "XGBOOST_LIB_CACHE", "XGBOOST_LIB_URL"] {
+            println!("cargo:rerun-if-env-changed={var}");
+        }
+
         if let Ok(xgboost_lib_dir) = std::env::var("XGBOOST_LIB_DIR") {
             println!("cargo:rustc-link-search=native={}", xgboost_lib_dir);
-        } else {
+        } else if let Some(platform) = prebuilt_platform() {
             let deps_path = dunce::canonicalize(Path::new(&format!("{}/../../../deps", out_dir))).unwrap();
-            let deps_path = deps_path.to_string_lossy();
-            println!("cargo:rustc-link-search=native={}", deps_path);
-            if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-                let path = format!("{GITHUB_URL}/mac_arm64");
-                if !std::fs::exists(format!("{deps_path}/libxgboost.dylib")).unwrap() {
-                    web_copy(
-                        &format!("{path}/libxgboost.dylib"),
-                        &format!("{deps_path}/libxgboost.dylib"),
-                    )
-                    .unwrap();
-                    web_copy(&format!("{path}/libdmlc.a"), &format!("{deps_path}/libdmlc.a")).unwrap();
-                }
-            } else if cfg!(target_os = "linux") {
-                let path = if cfg!(target_arch = "aarch64") {
-                    format!("{GITHUB_URL}/linux_arm64")
-                } else {
-                    format!("{GITHUB_URL}/linux_amd64")
-                };
-                if !std::fs::exists(format!("{deps_path}/libxgboost.so")).unwrap() {
-                    web_copy(&format!("{path}/libxgboost.so"), &format!("{deps_path}/libxgboost.so")).unwrap();
-                    web_copy(&format!("{path}/libdmlc.a"), &format!("{deps_path}/libdmlc.a")).unwrap();
-                }
-            } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-                let path = format!("{GITHUB_URL}/win_amd64");
-                if !std::fs::exists(format!("{deps_path}/xgboost.dll")).unwrap() {
-                    web_copy(&format!("{path}/xgboost.dll"), &format!("{deps_path}/xgboost.dll")).unwrap();
-                    web_copy(&format!("{path}/xgboost.lib"), &format!("{deps_path}/xgboost.lib")).unwrap();
-                }
-            } else {
-                if let Ok(homebrew_path) = std::env::var("HOMEBREW_PREFIX") {
-                    let xgboost_lib_dir = format!("{}/opt/xgboost/lib", &homebrew_path);
-                    println!("cargo:rustc-link-search=native={}", xgboost_lib_dir);
-                } else {
-                    panic!("Please set $XGBOOST_LIB_DIR")
+            println!("cargo:rustc-link-search=native={}", deps_path.display());
+            for artifact in prebuilt_artifacts(platform) {
+                if let Err(e) = provide_artifact(platform, artifact, &deps_path) {
+                    if artifact.required {
+                        panic!(
+                            "Could not obtain prebuilt {}/{}: {e}\n\
+                             Set $XGBOOST_LIB_DIR to a directory holding a prebuilt xgboost library, \
+                             $XGBOOST_LIB_CACHE to a directory holding the artifacts, or \
+                             $XGBOOST_LIB_URL to a mirror base URL.",
+                            platform, artifact.file
+                        );
+                    }
+                    println!("cargo:warning=optional artifact {} unavailable: {e}", artifact.file);
                 }
             }
+        } else if let Ok(homebrew_path) = std::env::var("HOMEBREW_PREFIX") {
+            let xgboost_lib_dir = format!("{}/opt/xgboost/lib", &homebrew_path);
+            println!("cargo:rustc-link-search=native={}", xgboost_lib_dir);
+        } else {
+            panic!("Please set $XGBOOST_LIB_DIR")
         }
     }
 
@@ -123,11 +125,317 @@ fn main() {
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+/// One prebuilt file, pinned by content hash so a truncated or error-page download can never be
+/// mistaken for the real library.
 #[cfg(feature = "use_prebuilt_xgb")]
-fn web_copy(web_src: &str, target: &str) -> Result<()> {
-    dbg!(&web_src);
-    let resp = reqwest::blocking::get(web_src)?;
-    let body = resp.bytes()?;
-    std::fs::write(target, &body)?;
+struct Artifact {
+    file: &'static str,
+    sha256: &'static str,
+    /// `false` for files that are fetched for convenience but not linked against, so a failure to
+    /// obtain them must not break the build.
+    required: bool,
+}
+
+/// Prebuilt libraries are only published for these targets.
+///
+/// Note: `cfg!` in a build script describes the host, matching the previous behaviour. Cross
+/// compilation would need `CARGO_CFG_TARGET_OS` / `CARGO_CFG_TARGET_ARCH` instead.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn prebuilt_platform() -> Option<&'static str> {
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        Some("mac_arm64")
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        Some("linux_arm64")
+    } else if cfg!(target_os = "linux") {
+        Some("linux_amd64")
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        Some("win_amd64")
+    } else {
+        None
+    }
+}
+
+/// Checksums are of the files committed under `xgboost-sys/lib/`, which are the same blobs the
+/// mirrors serve for [`LIB_TAG`].
+///
+/// `libdmlc.a` is only linked by the `local_build` feature, so it is not required here.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn prebuilt_artifacts(platform: &str) -> &'static [Artifact] {
+    match platform {
+        "mac_arm64" => &[
+            Artifact {
+                file: "libxgboost.dylib",
+                sha256: "e438dacf4a1ec44e4f5f1e5005f291f7b66156af7fc49e543b60a5fdc079c024",
+                required: true,
+            },
+            Artifact {
+                file: "libdmlc.a",
+                sha256: "9670e7587af234cbbdf6eef8f2241ebe64074a09aecc36551ad38e18e94dd7b0",
+                required: false,
+            },
+        ],
+        "linux_amd64" => &[
+            Artifact {
+                file: "libxgboost.so",
+                sha256: "9f710fabebce59e1142942b0b95cad4f4088847224684ed52f12aa6f98c5b20b",
+                required: true,
+            },
+            Artifact {
+                file: "libdmlc.a",
+                sha256: "b8c472437a5153a4549f82f85c53a6ba482dae28b180d68ad87297e394e0a999",
+                required: false,
+            },
+        ],
+        "linux_arm64" => &[
+            Artifact {
+                file: "libxgboost.so",
+                sha256: "03b57ea7ad289c40143fe91637face8af4ff4979c962f2fcfae6227f53443166",
+                required: true,
+            },
+            Artifact {
+                file: "libdmlc.a",
+                sha256: "8cff76772920bf70688de75da8b3e219f28c179fc42bbbd16d8d89548746e7fe",
+                required: false,
+            },
+        ],
+        "win_amd64" => &[
+            Artifact {
+                file: "xgboost.dll",
+                sha256: "831b8fbeb97a879712e315a34ed36b26e9a297ca768317ed930b8a623bd5ccc1",
+                required: true,
+            },
+            Artifact {
+                file: "xgboost.lib",
+                sha256: "0ac9f77281d584c0d9f6ec67cbc7ee143fa21f777ca9446945c619c47802a05c",
+                required: true,
+            },
+        ],
+        _ => &[],
+    }
+}
+
+/// Place `artifact` in `deps_path`, preferring sources that need no network at all.
+///
+/// Order: an already-valid copy in `deps_path`, then the local directories from
+/// [`local_lib_dirs`], then the mirrors. Anything that fails its checksum is discarded and the
+/// next source is tried, so a bad file can never persist across builds.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn provide_artifact(platform: &str, artifact: &Artifact, deps_path: &Path) -> Result<()> {
+    let dest = deps_path.join(artifact.file);
+
+    if dest.exists() {
+        if let Ok(bytes) = std::fs::read(&dest) {
+            let actual = sha256_hex(&bytes);
+            // The stamp records what the file must hash to after `install_artifact` rewrote it.
+            if std::fs::read_to_string(stamp_path(&dest)).ok().as_deref() == Some(actual.as_str()) {
+                return Ok(());
+            }
+            if actual == artifact.sha256 {
+                // Intact, but left by a build that predates `install_artifact`. Finalize it in
+                // place rather than re-fetching bytes we already have.
+                install_artifact(&dest, &bytes)?;
+                return Ok(());
+            }
+        }
+        // A previous build stored a truncated file or an HTML error page. Drop it so this build
+        // can heal itself instead of failing at link time forever.
+        println!("cargo:warning=discarding corrupt {}, re-fetching", dest.display());
+        std::fs::remove_file(&dest)?;
+        let _ = std::fs::remove_file(stamp_path(&dest));
+    }
+
+    for dir in local_lib_dirs(platform) {
+        let src = dir.join(artifact.file);
+        if let Ok(bytes) = std::fs::read(&src) {
+            if sha256_hex(&bytes) == artifact.sha256 {
+                install_artifact(&dest, &bytes)?;
+                return Ok(());
+            }
+            println!("cargo:warning=ignoring {} (checksum mismatch)", src.display());
+        }
+    }
+
+    let mut errors = Vec::new();
+    for base in mirror_bases() {
+        let url = mirror_url(&base, platform, artifact.file);
+        match download_verified(&url, artifact.sha256) {
+            Ok(bytes) => {
+                install_artifact(&dest, &bytes)?;
+                cache_store(platform, artifact.file, &bytes);
+                return Ok(());
+            }
+            Err(e) => errors.push(format!("  {url}: {e}")),
+        }
+    }
+    Err(format!("all sources failed:\n{}", errors.join("\n")).into())
+}
+
+/// Put verified bytes in place and make the result loadable from `deps`.
+///
+/// macOS copies a dependency's own `install_name` into every binary linking it, and the prebuilt
+/// dylibs carry an absolute Homebrew path. Without this rewrite the pinned library is put in place
+/// and then ignored at run time in favour of whatever happens to sit at that path — which may be a
+/// different, ABI-incompatible XGBoost. Since the rewrite changes the file, its post-rewrite hash
+/// is stamped alongside so later builds can still tell intact from corrupt.
+///
+/// The new name is `dest` itself rather than an `@rpath` entry, because a `-sys` crate cannot add
+/// an rpath to the binaries of the packages that depend on it.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn install_artifact(dest: &Path, bytes: &[u8]) -> Result<()> {
+    write_atomic(dest, bytes)?;
+    if cfg!(target_os = "macos") && dest.extension().is_some_and(|ext| ext == "dylib") {
+        let status = std::process::Command::new("install_name_tool")
+            .arg("-id")
+            .arg(dest)
+            .arg(dest)
+            .status()?;
+        if !status.success() {
+            return Err(format!("install_name_tool -id failed for {}", dest.display()).into());
+        }
+        // Rewriting the load command invalidates the signature, and arm64 macOS refuses to map an
+        // incorrectly signed image, killing the process at load time. Re-sign ad-hoc.
+        let status = std::process::Command::new("codesign")
+            .args(["--force", "--sign", "-"])
+            .arg(dest)
+            .status()?;
+        if !status.success() {
+            return Err(format!("codesign failed for {}", dest.display()).into());
+        }
+    }
+    std::fs::write(stamp_path(dest), sha256_hex(&std::fs::read(dest)?))?;
     Ok(())
+}
+
+#[cfg(feature = "use_prebuilt_xgb")]
+fn stamp_path(dest: &Path) -> PathBuf {
+    let mut path = dest.as_os_str().to_os_string();
+    path.push(".sha256");
+    PathBuf::from(path)
+}
+
+/// Directories searched before going to the network: an explicit cache, the default cache under
+/// `CARGO_HOME`, and the copies committed in this repository (absent from the published crate,
+/// which excludes `lib/*`).
+#[cfg(feature = "use_prebuilt_xgb")]
+fn local_lib_dirs(platform: &str) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(cache) = cache_dir() {
+        dirs.push(cache.join(platform));
+    }
+    if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
+        dirs.push(Path::new(&manifest).join("lib").join(platform));
+    }
+    dirs
+}
+
+#[cfg(feature = "use_prebuilt_xgb")]
+fn cache_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("XGBOOST_LIB_CACHE") {
+        return Some(PathBuf::from(dir));
+    }
+    let cargo_home = std::env::var("CARGO_HOME").ok().map(PathBuf::from).or_else(|| {
+        std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok()
+            .map(|h| Path::new(&h).join(".cargo"))
+    })?;
+    Some(cargo_home.join("xgboost-prebuilt").join(LIB_TAG))
+}
+
+/// Keep a verified copy outside `target/`, so a `cargo clean` or a second checkout does not
+/// re-download 15 MB.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn cache_store(platform: &str, file: &str, bytes: &[u8]) {
+    if let Some(dir) = cache_dir().map(|d| d.join(platform)) {
+        if std::fs::create_dir_all(&dir).is_ok() {
+            let _ = write_atomic(&dir.join(file), bytes);
+        }
+    }
+}
+
+#[cfg(feature = "use_prebuilt_xgb")]
+fn mirror_bases() -> Vec<String> {
+    let mut bases: Vec<String> = std::env::var("XGBOOST_LIB_URL").into_iter().collect();
+    bases.extend(MIRRORS.iter().map(|m| m.to_string()));
+    bases
+}
+
+/// GitHub release assets live in a flat namespace, so the platform becomes a filename prefix
+/// there; every other mirror uses a directory per platform.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn mirror_url(base: &str, platform: &str, file: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if base.contains("/releases/download/") {
+        format!("{base}/{platform}-{file}")
+    } else {
+        format!("{base}/{platform}/{file}")
+    }
+}
+
+/// Download `url`, retrying transient failures, and return the body only if it hashes to
+/// `expected_sha256`.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn download_verified(url: &str, expected_sha256: &str) -> Result<Vec<u8>> {
+    const ATTEMPTS: u32 = 3;
+    /// The libraries run to tens of megabytes, far past ureq's 10 MB default body limit.
+    const MAX_BODY: u64 = 256 * 1024 * 1024;
+
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(300)))
+        .build()
+        .into();
+
+    let mut last_err = None;
+    for attempt in 0..ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_secs(1 << attempt));
+        }
+        // ureq treats 4xx/5xx as errors by default, so an outage page cannot reach the checksum
+        // step, let alone the disk.
+        let result = agent.get(url).call().map_err(|e| e.to_string()).and_then(|mut resp| {
+            resp.body_mut()
+                .with_config()
+                .limit(MAX_BODY)
+                .read_to_vec()
+                .map_err(|e| e.to_string())
+        });
+        match result {
+            Ok(body) => {
+                let actual = sha256_hex(&body);
+                if actual == expected_sha256 {
+                    return Ok(body);
+                }
+                last_err = Some(format!(
+                    "checksum mismatch ({} bytes, sha256 {actual}, expected {expected_sha256})",
+                    body.len()
+                ));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| "download failed".into()).into())
+}
+
+/// Write via a temporary file in the same directory, so an interrupted build leaves no
+/// half-written library behind.
+#[cfg(feature = "use_prebuilt_xgb")]
+fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<()> {
+    let tmp = dest.with_extension(format!("tmp{}", std::process::id()));
+    std::fs::write(&tmp, bytes)?;
+    if let Err(e) = std::fs::rename(&tmp, dest) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "use_prebuilt_xgb")]
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut out = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
 }

--- a/xgboost-sys/build.rs
+++ b/xgboost-sys/build.rs
@@ -9,13 +9,14 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "use_prebuilt_xgb")]
 const LIB_TAG: &str = "v3.0.5";
 
-/// Base URLs tried in order when an artifact has to be downloaded. Each entry is expanded by
+/// Base URLs tried in order when an artifact has to be downloaded. `{tag}` is replaced with
+/// [`LIB_TAG`], so the tag is pinned in exactly one place. Each entry is expanded further by
 /// `mirror_url`, so a mirror may lay its files out either as `<base>/<platform>/<file>` or, for
 /// GitHub release assets, as `<base>/<platform>-<file>`.
 #[cfg(feature = "use_prebuilt_xgb")]
 const MIRRORS: &[&str] = &[
-    "https://github.com/marcomq/rust-xgboost/raw/refs/tags/v3.0.5/xgboost-sys/lib",
-    "https://github.com/marcomq/rust-xgboost/releases/download/v3.0.5",
+    "https://github.com/marcomq/rust-xgboost/raw/refs/tags/{tag}/xgboost-sys/lib",
+    "https://github.com/marcomq/rust-xgboost/releases/download/{tag}",
 ];
 
 fn main() {
@@ -226,14 +227,19 @@ fn provide_artifact(platform: &str, artifact: &Artifact, deps_path: &Path) -> Re
     if dest.exists() {
         if let Ok(bytes) = std::fs::read(&dest) {
             let actual = sha256_hex(&bytes);
-            // The stamp records what the file must hash to after `install_artifact` rewrote it.
-            if std::fs::read_to_string(stamp_path(&dest)).ok().as_deref() == Some(actual.as_str()) {
-                return Ok(());
+            // The stamp records the pinned hash and what the file must hash to after
+            // `install_artifact` rewrote it. Both have to match: the second catches corruption,
+            // the first catches a file left behind by a build that pinned a different version.
+            if let Ok(stamp) = std::fs::read_to_string(stamp_path(&dest)) {
+                let mut lines = stamp.lines();
+                if lines.next() == Some(artifact.sha256) && lines.next() == Some(actual.as_str()) {
+                    return Ok(());
+                }
             }
             if actual == artifact.sha256 {
                 // Intact, but left by a build that predates `install_artifact`. Finalize it in
                 // place rather than re-fetching bytes we already have.
-                install_artifact(&dest, &bytes)?;
+                install_artifact(&dest, &bytes, artifact.sha256)?;
                 return Ok(());
             }
         }
@@ -248,7 +254,7 @@ fn provide_artifact(platform: &str, artifact: &Artifact, deps_path: &Path) -> Re
         let src = dir.join(artifact.file);
         if let Ok(bytes) = std::fs::read(&src) {
             if sha256_hex(&bytes) == artifact.sha256 {
-                install_artifact(&dest, &bytes)?;
+                install_artifact(&dest, &bytes, artifact.sha256)?;
                 return Ok(());
             }
             println!("cargo:warning=ignoring {} (checksum mismatch)", src.display());
@@ -260,7 +266,7 @@ fn provide_artifact(platform: &str, artifact: &Artifact, deps_path: &Path) -> Re
         let url = mirror_url(&base, platform, artifact.file);
         match download_verified(&url, artifact.sha256) {
             Ok(bytes) => {
-                install_artifact(&dest, &bytes)?;
+                install_artifact(&dest, &bytes, artifact.sha256)?;
                 cache_store(platform, artifact.file, &bytes);
                 return Ok(());
             }
@@ -276,12 +282,13 @@ fn provide_artifact(platform: &str, artifact: &Artifact, deps_path: &Path) -> Re
 /// dylibs carry an absolute Homebrew path. Without this rewrite the pinned library is put in place
 /// and then ignored at run time in favour of whatever happens to sit at that path — which may be a
 /// different, ABI-incompatible XGBoost. Since the rewrite changes the file, its post-rewrite hash
-/// is stamped alongside so later builds can still tell intact from corrupt.
+/// is stamped alongside the pinned one, so later builds can tell an intact copy from a corrupt one
+/// and from one installed for a different pin.
 ///
 /// The new name is `dest` itself rather than an `@rpath` entry, because a `-sys` crate cannot add
 /// an rpath to the binaries of the packages that depend on it.
 #[cfg(feature = "use_prebuilt_xgb")]
-fn install_artifact(dest: &Path, bytes: &[u8]) -> Result<()> {
+fn install_artifact(dest: &Path, bytes: &[u8], expected_sha256: &str) -> Result<()> {
     write_atomic(dest, bytes)?;
     if cfg!(target_os = "macos") && dest.extension().is_some_and(|ext| ext == "dylib") {
         let status = std::process::Command::new("install_name_tool")
@@ -302,7 +309,8 @@ fn install_artifact(dest: &Path, bytes: &[u8]) -> Result<()> {
             return Err(format!("codesign failed for {}", dest.display()).into());
         }
     }
-    std::fs::write(stamp_path(dest), sha256_hex(&std::fs::read(dest)?))?;
+    let installed = sha256_hex(&std::fs::read(dest)?);
+    std::fs::write(stamp_path(dest), format!("{expected_sha256}\n{installed}\n"))?;
     Ok(())
 }
 
@@ -356,7 +364,7 @@ fn cache_store(platform: &str, file: &str, bytes: &[u8]) {
 #[cfg(feature = "use_prebuilt_xgb")]
 fn mirror_bases() -> Vec<String> {
     let mut bases: Vec<String> = std::env::var("XGBOOST_LIB_URL").into_iter().collect();
-    bases.extend(MIRRORS.iter().map(|m| m.to_string()));
+    bases.extend(MIRRORS.iter().map(|m| m.replace("{tag}", LIB_TAG)));
     bases
 }
 
@@ -420,7 +428,14 @@ fn download_verified(url: &str, expected_sha256: &str) -> Result<Vec<u8>> {
 /// half-written library behind.
 #[cfg(feature = "use_prebuilt_xgb")]
 fn write_atomic(dest: &Path, bytes: &[u8]) -> Result<()> {
-    let tmp = dest.with_extension(format!("tmp{}", std::process::id()));
+    // Suffix the whole file name rather than replacing the extension: `xgboost.dll` and
+    // `xgboost.lib` would otherwise share a temporary path within one build.
+    let mut name = dest
+        .file_name()
+        .ok_or_else(|| format!("no file name in destination {}", dest.display()))?
+        .to_os_string();
+    name.push(format!(".tmp{}", std::process::id()));
+    let tmp = dest.with_file_name(name);
     std::fs::write(&tmp, bytes)?;
     if let Err(e) = std::fs::rename(&tmp, dest) {
         let _ = std::fs::remove_file(&tmp);


### PR DESCRIPTION
avoid build issues on gh downtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable prebuilt XGBoost library acquisition with local cache, repository, and custom mirror support.
  * Added SHA-256 verification, automatic repair of corrupted files, download retries, and offline-build options.
  * Improved macOS compatibility through library path updates and ad-hoc signing.
* **Documentation**
  * Expanded setup guidance covering source priority, verification, mirrors, offline builds, and macOS behavior.
* **Maintenance**
  * Updated package releases to versions 3.0.6 and 3.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->